### PR TITLE
Explicit Verbiage About @Doc and defp.

### DIFF
--- a/master/elixir/writing-documentation.html
+++ b/master/elixir/writing-documentation.html
@@ -136,6 +136,7 @@ end</code></pre>
 </li>
 </ul>
 <h2 id="documentation-comments"> Documentation != Comments</h2><p>Elixir treats documentation and code comments as different concepts. Documentation are for users of your API, be it your co-worker or your future self. Modules and functions must always be documented if they are part of your application public interface (API).</p>
+<p>It's also important to understand that even if you add the <code class="inline">@doc</code> attribute in front of a private function, it will be ignored. If you feel you need to document the function then consider if it might be wiser to make the function public or to create good code comments.</p>
 <p>Code comments are for developers reading the code. They are useful to mark improvements, leave notes for developers reading the code (for example, you decided to not call a function due to a bug in a library) and so forth.</p>
 <p>In other words, documentation is required, code comments are optional.</p>
 <h2 id="code-get_docs-2"> Code.get_docs/2</h2><p>Elixir stores documentation inside pre-defined chunks in the bytecode. It can be accessed from Elixir by using the <a href="Code.html#get_docs/2"><code class="inline">Code.get_docs/2</code></a> function. This also means documentation is only accessed when required and not when modules are loaded by the Virtual Machine. The only downside is that modules defined in-memory, like the ones defined in IEx, cannot have their documentation accessed as they do not have their bytecode written to disk.</p>


### PR DESCRIPTION
Adding a paragraph to explicitly spell out the behavior of the @doc attribute in relation to private functions.