### PR TITLE
Add missing ) for init/3 callback

### DIFF
--- a/v1.3/elixir/GenServer.html
+++ b/v1.3/elixir/GenServer.html
@@ -1262,7 +1262,7 @@ a timeout occurs the message is <code class="inline">:timeout</code>.</p>
   
   <section class="docstring">
     <p>Invoked when the server is started. <a href="#start_link/3"><code class="inline">start_link/3</code></a> (or <a href="#start/3)"><code class="inline">start/3</code></a> will
-block until it returns.</p>
+block until it returns.)</p>
 <p><code class="inline">args</code> is the argument term (second argument) passed to <a href="#start_link/3"><code class="inline">start_link/3</code></a>.</p>
 <p>Returning <code class="inline">{:ok, state}</code> will cause <a href="#start_link/3"><code class="inline">start_link/3</code></a> to return
 <code class="inline">{:ok, pid}</code> and the process to enter its loop.</p>


### PR DESCRIPTION
While reading through the docs, i noticed a missing bracket for the `init/3` description.

Thought i would go ahead and add it. 

Thanks!