### PR TITLE
Minor typo fix

### DIFF
--- a/stable/elixir/writing-documentation.html
+++ b/stable/elixir/writing-documentation.html
@@ -187,7 +187,7 @@ end</code></pre>
 </h2>
 
 <p>Elixir warns if a private function has a <code class="inline">@doc</code> attribute and discards its content, because <code class="inline">@doc</code> is intended to be used only for your public interface.</p>
-<p>Private functions may still need internal documentation for maintainers, though. That can be accomplished with code commments.</p>
+<p>Private functions may still need internal documentation for maintainers, though. That can be accomplished with code comments.</p>
 <h2 id="code-get_docs-2" class="section-heading">
   <a href="#code-get_docs-2" class="hover-link"><i class="icon-link"></i></a>
   Code.get_docs/2


### PR DESCRIPTION
It said "commments". Should've said "comments".